### PR TITLE
add authentication-popup.html translations

### DIFF
--- a/fr_fr.module.magento_customer.csv
+++ b/fr_fr.module.magento_customer.csv
@@ -96,8 +96,8 @@
 "Change Shipping Address","Modifier",module,Magento_Customer
 "Check out faster","Consultation rapide",module,Magento_Customer
 "Check the status of orders","Vérifier le statut des commandes",module,Magento_Customer
-"Checkout out as a new customer","Passer au paiement de votre nouvelle session",module,Magento_Customer
-"Checkout out using your account","Passer au paiement en tant que nouveau cliente",module,Magento_Customer
+"Checkout out as a new customer","Passer au paiement en tant que nouveau client",module,Magento_Customer
+"Checkout out using your account","Passer au paiement de votre compte",module,Magento_Customer
 "City","Ville",module,Magento_Customer
 "Company","Société",module,Magento_Customer
 "Configure","Configurer",module,Magento_Customer

--- a/fr_fr.module.magento_customer.csv
+++ b/fr_fr.module.magento_customer.csv
@@ -96,8 +96,8 @@
 "Change Shipping Address","Modifier",module,Magento_Customer
 "Check out faster","Consultation rapide",module,Magento_Customer
 "Check the status of orders","Vérifier le statut des commandes",module,Magento_Customer
-"Checkout out as a new customer","Se déconnecter de votre nouvelle session",module,Magento_Customer
-"Checkout out using your account","Se déconnecter de votre compte",module,Magento_Customer
+"Checkout out as a new customer","Passer au paiement de votre nouvelle session",module,Magento_Customer
+"Checkout out using your account","Passer au paiement en tant que nouveau cliente",module,Magento_Customer
 "City","Ville",module,Magento_Customer
 "Company","Société",module,Magento_Customer
 "Configure","Configurer",module,Magento_Customer
@@ -391,7 +391,7 @@
 "Reset Password Template","Gabarit de réinitialisation de mot de passe",module,Magento_Customer
 "Reset password token expired.","Réinitialisation du mot de passe expiré.",module,Magento_Customer
 "Reset password token mismatch.","Le jeton de réinitialisation de mot de passe ne correspond pas.",module,Magento_Customer
-"See order and shipping status","Se déconnecter de votre compte",module,Magento_Customer
+"See order and shipping status","Voir le statut de la commande et de l'expédition",module,Magento_Customer
 "Sales Statistics","Statistiques de ventes",module,Magento_Customer
 "Save","Sauvegarder",module,Magento_Customer
 "Save Address","Sauvegarder l'adresse",module,Magento_Customer
@@ -523,7 +523,7 @@
 "To sign in to our site and set a password, click on the <a href=""%create_password_url"">link</a>:","Pour vous connecter sur notre site et définir un mot de passe, cliquez sur ce <a href=""%create_password_url"">lien</a>:",module,Magento_Customer
 "To sign in to our site, use these credentials during checkout or on the <a href=""%customer_url"">My Account</a> page:","Pour vous connecter, utilisez les identifiants renseignés lors de votre commande ou en vous rendant sur la page <a href=""%customer_url"">Mon Compte</a>:",module,Magento_Customer
 "Total","Total",module,Magento_Customer
-"Track order history","Voir le statut de la commande et de l'expédition",module,Magento_Customer
+"Track order history","Suivi de la commande",module,Magento_Customer
 "Type","Type",module,Magento_Customer
 "Unable to send password reset email.","Impossible d'envoyer l'email de réinitialisation du mot de passe.",module,Magento_Customer
 "Unknown","Inconnu",module,Magento_Customer


### PR DESCRIPTION
Add missing translations for Magento_Customer/view/frontend/web/template/authentication-popup.html. It shows after click to "Go to checkout" button when "Allow guest checkout" admin option is off.